### PR TITLE
ci(release): add GoReleaser config and workflow for multi-OS/arch binary builds

### DIFF
--- a/.github/workflows/binary-releaser.yml
+++ b/.github/workflows/binary-releaser.yml
@@ -1,0 +1,32 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  # packages: write
+  # issues: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+

--- a/.github/workflows/version-bumper.yml
+++ b/.github/workflows/version-bumper.yml
@@ -1,0 +1,58 @@
+name: Version Bumper
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get current and previous tags
+        id: tags
+        run: |
+          git fetch --tags
+          CURRENT_TAG=${GITHUB_REF_NAME#v}
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep '^v' | sed -n 2p | sed 's/^v//')
+          echo "current=$CURRENT_TAG" >> $GITHUB_OUTPUT
+          echo "previous=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
+
+      - name: Bump chart version
+        id: bump
+        run: |
+          FILE=manifests/helm/Chart.yaml
+          README=README.md
+
+          APP_PREVIOUS="${{ steps.tags.outputs.previous }}"
+          APP_CURRENT="${{ steps.tags.outputs.current }}"
+
+          IFS='.' read -r prev_major prev_minor prev_patch <<< "$APP_PREVIOUS"
+          IFS='.' read -r curr_major curr_minor curr_patch <<< "$APP_CURRENT"
+          IFS='.' read -r chart_major chart_minor chart_patch <<< "$(grep '^version:' "$FILE" | awk '{print $2}')"
+
+          [ "$curr_major" != "$prev_major" ] && chart_major=$((chart_major + 1))
+          [ "$curr_minor" != "$prev_minor" ] && chart_minor=$((chart_minor + 1))
+          [ "$curr_patch" != "$prev_patch" ] && chart_patch=$((chart_patch + 1))
+
+          NEW_CHART_VERSION="${chart_major}.${chart_minor}.${chart_patch}"
+
+          sed -i "s/^version: .*/version: $NEW_CHART_VERSION/" "$FILE"
+          sed -i "s/^appVersion: .*/appVersion: $APP_CURRENT/" "$FILE"
+          sed -i "s/--version [0-9.]*/--version $NEW_CHART_VERSION/" "$README"
+
+          echo "new=$NEW_CHART_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add manifests/helm/Chart.yaml README.md
+          git commit -m "chore(release): bump chart to ${{ steps.bump.outputs.new }} and update README for v${{ steps.tags.outputs.current }}"
+          git push origin HEAD:master

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ slimserve
 
 data/*.png
 data/*.jpg
+
+benchmark_results/*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,48 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - freebsd
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    main: ./cmd/slimserve/main.go
+
+archives:
+  - formats: binary
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  github:
+    owner: xeome
+    name: slimserve
+  footer: |-
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).
+
+checksum:
+  disable: true

--- a/README.md
+++ b/README.md
@@ -110,11 +110,8 @@ export HELM_EXPERIMENTAL_OCI=1
 #### Installing
 
 ```bash
-# Get latest version from GitHub API (requires curl and jq on your system)
-LATEST_VERSION=$(curl -fsSL https://api.github.com/repos/xeome/slimserve/tags | jq -r '.[].name' | sort -Vr | head -n 1 | sed 's/v//g')
-
 # Deploy SlimServe
-helm install slimserve oci://ghcr.io/xeome/slimserve-helm --version $LATEST_VERSION --namespace slimserve --create-namespace
+helm install slimserve oci://ghcr.io/xeome/slimserve-helm --version 1.0.0 --namespace slimserve --create-namespace
 ```
 
 ### Manual Docker Run


### PR DESCRIPTION
- Build binaries for Linux, macOS (Darwin), Windows, and FreeBSD
- Support both amd64 and arm64 architectures
- Automate releases triggered by semver tag pushes
- Generate platform-specific binaries with consistent naming